### PR TITLE
Implement single and multi instrument selection UI

### DIFF
--- a/.cursor/rules/code_cleanliness.mdc
+++ b/.cursor/rules/code_cleanliness.mdc
@@ -1,21 +1,25 @@
 ---
-description: 
-globs: 
+description:
+globs:
 alwaysApply: true
 ---
-# AI code editing rules for clean code and comments
+# AI Code Cleanliness and Commenting Rules
 
-**AI Assistant Instructions:** When editing or generating code, strictly adhere to the following:
+**AI Assistant Instructions:** When proposing code edits or generating new code, strictly adhere to the following:
 
-1. **Delete, Don't Comment Out:** AI Assistant MUST delete unused or replaced code entirely. NEVER leave old code commented out in the final proposed code change. **If unsure whether code is truly unused (e.g., potential side effects, complex interactions), ask for clarification before deleting.**
+1.  **Delete, Don't Comment Out:** AI Assistant MUST delete unused or replaced code entirely. NEVER leave old code commented out in the final proposed code change. **If unsure whether code is truly unused (e.g., potential side effects, complex interactions), ask for clarification before deleting.**
 
-2. **Comment Purposefully (Explain Why, Not What):**
-    * AI Assistant comments MUST focus on explaining the *reasoning* behind complex logic, non-obvious decisions, or potential edge cases/consequences.
-    * NEVER add comments that merely describe *what* the code does if its function is clear from the code itself (e.g., naming, standard patterns). **If unsure whether a comment explaining 'what' is necessary for clarity in a specific complex situation, err on the side of omitting it or ask for guidance.**
-    * NEVER add meta-comments describing the edit action itself (e.g., "// Refactored this", "// Fixed bug", "// Added CSS rule"). The commit message serves this purpose.
+2.  **Comment Purposefully (Explain ONLY Why, Not What):**
+    *   Comments MUST focus **exclusively** on explaining the *reasoning* ('why') behind complex logic, non-obvious decisions, or potential edge cases/consequences.
+    *   NEVER add comments that describe *what* the code does, even for organizational purposes (e.g., `// Get references`, `/* Styling for X */`). Rely on clear code structure, function/variable naming instead. **If unsure whether a comment explaining 'why' is needed, ask for guidance.**
+    *   NEVER add meta-comments describing the edit action itself (e.g., "// Refactored this", "// Added CSS rule").
 
-3. **Ensure Readability:** While adhering to the above, ensure the final code (including necessary comments explaining the 'why') is clear and understandable for human developers. Prioritize self-documenting code through clear naming and logic.
+3.  **Ensure Readability:** Prioritize self-documenting code through clear naming and logic. Ensure any necessary 'why' comments enhance clarity for human developers.
 
-4. **Clean Up:** Remove TODOs or placeholder comments when the corresponding task is completed.
+4.  **Clean Up:** Remove TODOs or placeholder comments when the corresponding task is completed.
 
-**Goal:** The final code produced by the AI should be clean, free of commented-out legacy code, and contain only comments that add essential context for future readers, not comments explaining the edit process. **Efficiency is gained by avoiding unnecessary comments and legacy code, but correctness (not deleting vital code or omitting critical explanations) takes precedence; seek clarification when deletion or commenting decisions are ambiguous.** 
+5.  **Final Review:** Before submitting the code change proposal, AI Assistant MUST perform a final review pass on the generated/edited code specifically to:
+    *   Confirm **all** commented-out legacy/replaced code has been deleted (Rule #1).
+    *   Confirm **all** comments describing 'what' the code does or the edit itself have been removed (Rule #2).
+
+**Goal:** The final code produced by the AI should be clean, free of commented-out legacy code, and contain only comments that add essential context ('why'). **Efficiency is gained by avoiding unnecessary comments and legacy code, but correctness takes precedence; seek clarification when deletion or commenting decisions are ambiguous.** 

--- a/.cursor/rules/code_cleanliness.mdc
+++ b/.cursor/rules/code_cleanliness.mdc
@@ -1,0 +1,21 @@
+---
+description: 
+globs: 
+alwaysApply: true
+---
+# AI code editing rules for clean code and comments
+
+**AI Assistant Instructions:** When editing or generating code, strictly adhere to the following:
+
+1. **Delete, Don't Comment Out:** AI Assistant MUST delete unused or replaced code entirely. NEVER leave old code commented out in the final proposed code change. **If unsure whether code is truly unused (e.g., potential side effects, complex interactions), ask for clarification before deleting.**
+
+2. **Comment Purposefully (Explain Why, Not What):**
+    * AI Assistant comments MUST focus on explaining the *reasoning* behind complex logic, non-obvious decisions, or potential edge cases/consequences.
+    * NEVER add comments that merely describe *what* the code does if its function is clear from the code itself (e.g., naming, standard patterns). **If unsure whether a comment explaining 'what' is necessary for clarity in a specific complex situation, err on the side of omitting it or ask for guidance.**
+    * NEVER add meta-comments describing the edit action itself (e.g., "// Refactored this", "// Fixed bug", "// Added CSS rule"). The commit message serves this purpose.
+
+3. **Ensure Readability:** While adhering to the above, ensure the final code (including necessary comments explaining the 'why') is clear and understandable for human developers. Prioritize self-documenting code through clear naming and logic.
+
+4. **Clean Up:** Remove TODOs or placeholder comments when the corresponding task is completed.
+
+**Goal:** The final code produced by the AI should be clean, free of commented-out legacy code, and contain only comments that add essential context for future readers, not comments explaining the edit process. **Efficiency is gained by avoiding unnecessary comments and legacy code, but correctness (not deleting vital code or omitting critical explanations) takes precedence; seek clarification when deletion or commenting decisions are ambiguous.** 

--- a/.cursor/rules/create_cursor_rules_guide.mdc
+++ b/.cursor/rules/create_cursor_rules_guide.mdc
@@ -1,0 +1,49 @@
+---
+description: USE WHEN creating or modifying Cursor rule (.mdc) files
+globs: 
+alwaysApply: false
+---
+# AI Rule: Creating Effective Cursor Rules
+
+**AI Assistant Instructions:** When asked to create or modify a Cursor rule file (`.mdc`), ensure the following structure and best practices are followed:
+
+**If the user's request for the rule is ambiguous regarding type, scope, or specific instructions, MUST ask for clarification before proceeding.**
+
+## 1. Frontmatter Configuration
+
+All Cursor rules MUST have YAML frontmatter containing `description`, `globs`, and `alwaysApply` fields. Configure these fields **exactly** according to the intended rule type (determined from user request or rule purpose):
+
+*   **`Always` Rules:**
+    *   `description:`
+    *   `globs:`
+    *   `alwaysApply: true`
+
+*   **`Auto Attached` Rules:**
+    *   `description:`
+    *   `globs: ["**/pattern1/*.ts", "**/pattern2/*.js"]` (Use specific patterns)
+    *   `alwaysApply: false`
+
+*   **`Agent Requested` Rules:**
+    *   `description: "USE WHEN [Concise, keyword-rich summary (max ~120 chars)]"` (Must start with 'USE WHEN')
+    *   `globs:`
+    *   `alwaysApply: false`
+
+*   **`Manual` Rules:**
+    *   `description:`
+    *   `globs:`
+    *   `alwaysApply: false`
+
+## 2. Rule Body Best Practices
+
+The rule body MUST contain clear, actionable instructions for the AI assistant that will *use* the rule later:
+
+*   **Use Imperative Language:** Employ strong directives (`MUST`, `NEVER`, `SHOULD`, `AVOID`, `PREFER`, `ENSURE`).
+*   **Be Specific & Unambiguous:** Define standards precisely. Avoid vague terms.
+*   **Focus on Actionable Steps:** Frame guidelines as tasks the AI can perform or checks it can make.
+*   **Provide Brief Context (Why):** Explain the reasoning *briefly* if it clarifies the instruction.
+*   **Use Markdown Formatting:** Leverage headings, lists, and bold text for clarity.
+*   **Address Ambiguity (for Target AI):** If the rule being created involves potential uncertainty for the target AI, include guidance on how it should seek clarification (e.g., "If unsure..., ask user...").
+*   **Keep it Concise:** Avoid unnecessary jargon or verbosity.
+*   **No Meta-Comments:** Do not include comments *within the rule being created* about the act of creating it.
+
+**Goal:** To generate rule files that are correctly configured according to their type and contain clear, specific, actionable instructions that effectively guide AI behavior according to the user's intent and project standards. 

--- a/.cursor/rules/create_cursor_rules_guide.mdc
+++ b/.cursor/rules/create_cursor_rules_guide.mdc
@@ -14,23 +14,23 @@ alwaysApply: false
 All Cursor rules MUST have YAML frontmatter containing `description`, `globs`, and `alwaysApply` fields. Configure these fields **exactly** according to the intended rule type (determined from user request or rule purpose):
 
 *   **`Always` Rules:**
-    *   `description:`
-    *   `globs:`
+    *   `description: `
+    *   `globs: `
     *   `alwaysApply: true`
 
 *   **`Auto Attached` Rules:**
-    *   `description:`
+    *   `description: `
     *   `globs: ["**/pattern1/*.ts", "**/pattern2/*.js"]` (Use specific patterns)
     *   `alwaysApply: false`
 
 *   **`Agent Requested` Rules:**
     *   `description: "USE WHEN [Concise, keyword-rich summary (max ~120 chars)]"` (Must start with 'USE WHEN')
-    *   `globs:`
+    *   `globs: `
     *   `alwaysApply: false`
 
 *   **`Manual` Rules:**
-    *   `description:`
-    *   `globs:`
+    *   `description: `
+    *   `globs: `
     *   `alwaysApply: false`
 
 ## 2. Rule Body Best Practices

--- a/.cursor/rules/no_fabrication.mdc
+++ b/.cursor/rules/no_fabrication.mdc
@@ -1,0 +1,21 @@
+---
+description: 
+globs: 
+alwaysApply: true
+---
+# AI Rule - Prevent Data Fabrication and Ensure Accuracy
+
+**AI Assistant Instructions:** Accuracy and honesty are paramount. Adhere strictly to these guidelines regarding data and information in all responses and code generation:
+
+1.  **NEVER Fabricate Data:** AI Assistant MUST NEVER invent, fabricate, create, or make up data, statistics, facts, metrics, or any information if it lacks sufficient, verifiable sources or explicit data provided in the context.
+
+2.  **Acknowledge Unknowns & Seek Clarity:** If the answer is unknown, uncertain, or cannot be determined from available information or tools, AI Assistant MUST clearly state this limitation. DO NOT provide speculative or guessed answers presented as fact. **If missing information is the primary blocker and seems reasonably obtainable from the user, consider asking clarifying questions before simply stating the limitation.** Accuracy is more important than providing a potentially incorrect answer.
+
+3.  **Use Safe Placeholders & Examples:**
+    *   When generating examples or code requiring placeholder data (e.g., user input, configuration values, API responses), use values that are **obviously generic and non-realistic** (e.g., "user@example.com", "123 Main St", `item_count = 5`, `PRODUCT_ID_XYZ`).
+    *   NEVER use placeholders that mimic real-world data formats or values so closely they could be mistaken for actual, sensitive, or specific data (e.g., realistic-looking social security numbers, credit card numbers, specific financial figures, personal names unless generic like "John Doe").
+    *   Clearly label all illustrative examples or code snippets containing placeholder data as such (e.g., "Example:", "Placeholder data shown below:").
+
+4.  **Analyze Only Provided Data:** When asked to analyze data, AI Assistant MUST limit the analysis strictly to the data explicitly provided in the context or accessed through authorized tools. DO NOT extrapolate beyond the given data or introduce external, unverified information into the analysis.
+
+5.  **Prioritize Verifiable Information:** When providing factual information or explanations, rely on the information available in the context or retrieved through authorized tools. Avoid making definitive statements not supported by the available information. 

--- a/.gitignore
+++ b/.gitignore
@@ -105,8 +105,3 @@ dist
 
 # VSCode
 .vscode/
-
-# Cursor files
-.cursorrules
-.cursorignore
-.cursor/

--- a/index.html
+++ b/index.html
@@ -68,6 +68,54 @@
 		<div class="control-group reset-group">
 			<button id="resetSettingsBtn" class="reset-btn">Reset to Defaults</button>
 		</div>
+
+		<!-- Add Instrument Checkbox Group -->
+		<fieldset class="control-group instrument-group">
+			<legend>Instruments (Select one or more)</legend>
+			<div class="instrument-checkbox-container">
+				<div>
+					<input type="checkbox" id="instr-piano" name="instrument" value="piano">
+					<label for="instr-piano">Piano</label>
+				</div>
+				<div>
+					<input type="checkbox" id="instr-vibraphone" name="instrument" value="vibraphone">
+					<label for="instr-vibraphone">Vibraphone</label>
+				</div>
+				<div>
+					<input type="checkbox" id="instr-twinkle" name="instrument" value="twinkle">
+					<label for="instr-twinkle">Twinkle</label>
+				</div>
+				<div>
+					<input type="checkbox" id="instr-sax" name="instrument" value="sax">
+					<label for="instr-sax">Sax</label>
+				</div>
+				<div>
+					<input type="checkbox" id="instr-sax2" name="instrument" value="sax2">
+					<label for="instr-sax2">Sax 2</label>
+				</div>
+				<div>
+					<input type="checkbox" id="instr-harp" name="instrument" value="harp">
+					<label for="instr-harp">Harp</label>
+				</div>
+				<div>
+					<input type="checkbox" id="instr-guzheng" name="instrument" value="guzheng">
+					<label for="instr-guzheng">Guzheng</label>
+				</div>
+				<div>
+					<input type="checkbox" id="instr-guitar" name="instrument" value="guitar">
+					<label for="instr-guitar">Guitar</label>
+				</div>
+				<div>
+					<input type="checkbox" id="instr-clarinet" name="instrument" value="clarinet">
+					<label for="instr-clarinet">Clarinet</label>
+				</div>
+			</div>
+		</fieldset>
+
+		<div class="control-group">
+			<label for="volumeSlider">Volume: <span id="volumeValueSpan" class="slider-value"></span></label>
+			<input type="range" id="volumeSlider" min="0" max="1" step="0.05">
+		</div>
 	</div>
 </body>
 

--- a/index.html
+++ b/index.html
@@ -10,6 +10,10 @@
 </head>
 
 <body>
+	<div id="welcome-banner" class="banner">
+		<p>Welcome to ComfyJazz! Press 'C' to toggle controls</p>
+		<button id="close-banner-btn" class="banner-close-btn" aria-label="Dismiss welcome message">&times;</button>
+	</div>
 	<div id="comfy-controls" class="control-panel hide">
 		<div class="panel-header">
 			<h2>ComfyJazz Controls</h2>

--- a/index.html
+++ b/index.html
@@ -20,21 +20,98 @@
 			<button id="close-controls-btn" class="close-btn" aria-label="Close controls panel">&times;</button>
 		</div>
 
-		<div class="control-group">
-			<label for="instrumentSelect">Instrument:</label>
-			<select id="instrumentSelect">
-				<option value="clarinet">Clarinet</option>
-				<option value="guitar">Guitar</option>
-				<option value="guzheng">Guzheng</option>
-				<option value="harp">Harp</option>
-				<option value="piano">Piano</option>
-				<option value="sax">Sax</option>
-				<option value="sax2">Sax 2</option>
-				<option value="twinkle">Twinkle</option>
-				<option value="vibraphone">Vibraphone</option>
-			</select>
-		</div>
+		<!-- Instrument Selection Area -->
+		<fieldset class="control-group instrument-section">
+			<legend>Instrument</legend>
+			<div class="instrument-mode-toggle">
+				 <input type="checkbox" id="toggleMultiInstrument">
+				 <label for="toggleMultiInstrument">Select Multiple Instruments</label>
+			</div>
 
+			<!-- Radio Button Container (Single Select - Default) -->
+			<div id="instrumentRadioContainer" class="instrument-container">
+				<!-- Radio buttons will be dynamically populated or listed here -->
+				 <div>
+					<input type="radio" id="instr-radio-piano" name="instrumentSingle" value="piano" checked>
+					<label for="instr-radio-piano">Piano</label>
+				 </div>
+				 <div>
+					<input type="radio" id="instr-radio-vibraphone" name="instrumentSingle" value="vibraphone">
+					<label for="instr-radio-vibraphone">Vibraphone</label>
+				 </div>
+				 <div>
+					<input type="radio" id="instr-radio-twinkle" name="instrumentSingle" value="twinkle">
+					<label for="instr-radio-twinkle">Twinkle</label>
+				 </div>
+				 <div>
+					<input type="radio" id="instr-radio-sax" name="instrumentSingle" value="sax">
+					<label for="instr-radio-sax">Sax</label>
+				 </div>
+				 <div>
+					<input type="radio" id="instr-radio-sax2" name="instrumentSingle" value="sax2">
+					<label for="instr-radio-sax2">Sax 2</label>
+				 </div>
+				 <div>
+					<input type="radio" id="instr-radio-harp" name="instrumentSingle" value="harp">
+					<label for="instr-radio-harp">Harp</label>
+				 </div>
+				 <div>
+					<input type="radio" id="instr-radio-guzheng" name="instrumentSingle" value="guzheng">
+					<label for="instr-radio-guzheng">Guzheng</label>
+				 </div>
+				 <div>
+					<input type="radio" id="instr-radio-guitar" name="instrumentSingle" value="guitar">
+					<label for="instr-radio-guitar">Guitar</label>
+				 </div>
+				 <div>
+					<input type="radio" id="instr-radio-clarinet" name="instrumentSingle" value="clarinet">
+					<label for="instr-radio-clarinet">Clarinet</label>
+				 </div>
+			</div>
+
+			<!-- Checkbox Container (Multi Select - Initially Hidden) -->
+			<div id="instrumentCheckboxContainer" class="instrument-container instrument-checkbox-container hide">
+				<!-- Checkboxes moved inside here -->
+				 <div>
+					<input type="checkbox" id="instr-check-piano" name="instrumentMulti" value="piano">
+					<label for="instr-check-piano">Piano</label>
+				 </div>
+				 <div>
+					<input type="checkbox" id="instr-check-vibraphone" name="instrumentMulti" value="vibraphone">
+					<label for="instr-check-vibraphone">Vibraphone</label>
+				 </div>
+				 <div>
+					<input type="checkbox" id="instr-check-twinkle" name="instrumentMulti" value="twinkle">
+					<label for="instr-check-twinkle">Twinkle</label>
+				 </div>
+				 <div>
+					<input type="checkbox" id="instr-check-sax" name="instrumentMulti" value="sax">
+					<label for="instr-check-sax">Sax</label>
+				 </div>
+				 <div>
+					<input type="checkbox" id="instr-check-sax2" name="instrumentMulti" value="sax2">
+					<label for="instr-check-sax2">Sax 2</label>
+				 </div>
+				 <div>
+					<input type="checkbox" id="instr-check-harp" name="instrumentMulti" value="harp">
+					<label for="instr-check-harp">Harp</label>
+				 </div>
+				 <div>
+					<input type="checkbox" id="instr-check-guzheng" name="instrumentMulti" value="guzheng">
+					<label for="instr-check-guzheng">Guzheng</label>
+				 </div>
+				 <div>
+					<input type="checkbox" id="instr-check-guitar" name="instrumentMulti" value="guitar">
+					<label for="instr-check-guitar">Guitar</label>
+				 </div>
+				 <div>
+					<input type="checkbox" id="instr-check-clarinet" name="instrumentMulti" value="clarinet">
+					<label for="instr-check-clarinet">Clarinet</label>
+				 </div>
+			</div>
+		</fieldset>
+
+		<!-- Volume Control -->
 		<div class="control-group">
 			<label for="volumeSlider">Volume: <span id="volumeValueSpan" class="slider-value"></span></label>
 			<input type="range" id="volumeSlider" min="0" max="1" step="0.05">
@@ -67,54 +144,6 @@
 		<!-- Add Reset Button -->
 		<div class="control-group reset-group">
 			<button id="resetSettingsBtn" class="reset-btn">Reset to Defaults</button>
-		</div>
-
-		<!-- Add Instrument Checkbox Group -->
-		<fieldset class="control-group instrument-group">
-			<legend>Instruments (Select one or more)</legend>
-			<div class="instrument-checkbox-container">
-				<div>
-					<input type="checkbox" id="instr-piano" name="instrument" value="piano">
-					<label for="instr-piano">Piano</label>
-				</div>
-				<div>
-					<input type="checkbox" id="instr-vibraphone" name="instrument" value="vibraphone">
-					<label for="instr-vibraphone">Vibraphone</label>
-				</div>
-				<div>
-					<input type="checkbox" id="instr-twinkle" name="instrument" value="twinkle">
-					<label for="instr-twinkle">Twinkle</label>
-				</div>
-				<div>
-					<input type="checkbox" id="instr-sax" name="instrument" value="sax">
-					<label for="instr-sax">Sax</label>
-				</div>
-				<div>
-					<input type="checkbox" id="instr-sax2" name="instrument" value="sax2">
-					<label for="instr-sax2">Sax 2</label>
-				</div>
-				<div>
-					<input type="checkbox" id="instr-harp" name="instrument" value="harp">
-					<label for="instr-harp">Harp</label>
-				</div>
-				<div>
-					<input type="checkbox" id="instr-guzheng" name="instrument" value="guzheng">
-					<label for="instr-guzheng">Guzheng</label>
-				</div>
-				<div>
-					<input type="checkbox" id="instr-guitar" name="instrument" value="guitar">
-					<label for="instr-guitar">Guitar</label>
-				</div>
-				<div>
-					<input type="checkbox" id="instr-clarinet" name="instrument" value="clarinet">
-					<label for="instr-clarinet">Clarinet</label>
-				</div>
-			</div>
-		</fieldset>
-
-		<div class="control-group">
-			<label for="volumeSlider">Volume: <span id="volumeValueSpan" class="slider-value"></span></label>
-			<input type="range" id="volumeSlider" min="0" max="1" step="0.05">
 		</div>
 	</div>
 </body>

--- a/main.ts
+++ b/main.ts
@@ -212,3 +212,34 @@ window.addEventListener("keydown", (e: KeyboardEvent): void => {
   }
 });
 
+// --- Banner Logic ---
+const welcomeBanner = document.getElementById('welcome-banner');
+const closeBannerBtn = document.getElementById('close-banner-btn');
+
+// Use ReturnType to get the correct type for setTimeout in the environment
+let fadeTimeoutId: ReturnType<typeof setTimeout> | null = null;
+let hideTimeoutId: ReturnType<typeof setTimeout> | null = null;
+
+function dismissBanner() {
+    if (welcomeBanner) {
+        welcomeBanner.classList.add('hide'); // Hide immediately
+    }
+    // Clear scheduled timeouts if dismissed manually
+    if (fadeTimeoutId !== null) clearTimeout(fadeTimeoutId);
+    if (hideTimeoutId !== null) clearTimeout(hideTimeoutId);
+}
+
+if (welcomeBanner && closeBannerBtn) {
+    // Automatic dismissal
+    fadeTimeoutId = setTimeout(() => {
+        welcomeBanner.classList.add('fade-out');
+        hideTimeoutId = setTimeout(() => {
+            // Use dismissBanner to ensure cleanup
+            dismissBanner();
+        }, 800); // Match faster CSS transition
+    }, 4000); // Keep initial delay or adjust as needed
+
+    // Manual dismissal via button
+    closeBannerBtn.addEventListener('click', dismissBanner);
+}
+

--- a/style.css
+++ b/style.css
@@ -199,3 +199,35 @@ label[for="playAutoNotesCheckbox"] {
 .banner.hide {
   display: none;
 }
+
+/* Instrument Checkbox Group Styling */
+.instrument-group legend {
+    margin-bottom: 8px; /* Add space below legend */
+}
+
+.instrument-checkbox-container {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr)); /* Responsive columns */
+    gap: 8px; /* Space between checkboxes */
+    max-height: 150px; /* Limit height and allow scrolling if needed */
+    overflow-y: auto; /* Add scrollbar if content overflows */
+    padding: 5px; /* Padding inside the container */
+    background-color: #e8e8e8; /* Slightly different background for the scroll area */
+    border-radius: 4px;
+}
+
+.instrument-checkbox-container div {
+    display: flex;
+    align-items: center;
+}
+
+.instrument-checkbox-container input[type="checkbox"] {
+    margin-right: 6px;
+}
+
+.instrument-checkbox-container label {
+    font-weight: normal; /* Normal weight for checkbox labels */
+    margin-bottom: 0; /* Override default label margin */
+    font-size: 0.9em; /* Match other control labels */
+    cursor: pointer; /* Indicate labels are clickable */
+}

--- a/style.css
+++ b/style.css
@@ -27,6 +27,11 @@
   min-width: 300px; /* Adjust as needed */
   color: #333;
   font-family: sans-serif; /* Add a default font */
+  /* Prevent text selection */
+  user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
 }
 
 .panel-header {
@@ -143,4 +148,54 @@ label[for="playAutoNotesCheckbox"] {
 
 .reset-btn:hover {
   background-color: #5a6268;
+}
+
+/* Welcome Banner Styling */
+.banner {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  width: 300px;
+  background-color: rgba(245, 245, 250, 0.9);
+  color: #555;
+  text-align: left;
+  padding: 12px 15px;
+  padding-right: 35px;
+  font-size: 0.85em;
+  font-family: "Segoe UI", Candara, "DejaVu Sans", "Bitstream Vera Sans", Inter, -apple-system, BlinkMacSystemFont, sans-serif;
+  z-index: 1001;
+  opacity: 1;
+  transition: opacity 0.8s ease-out;
+  border-radius: 5px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
+}
+
+.banner p {
+    margin: 0;
+}
+
+/* Style for the close button inside the banner */
+.banner-close-btn {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  background: none;
+  border: none;
+  font-size: 1.2em;
+  line-height: 1;
+  color: #777;
+  cursor: pointer;
+  padding: 5px;
+}
+
+.banner-close-btn:hover {
+  color: #333;
+}
+
+.banner.fade-out {
+  opacity: 0;
+}
+
+.banner.hide {
+  display: none;
 }

--- a/style.css
+++ b/style.css
@@ -231,3 +231,59 @@ label[for="playAutoNotesCheckbox"] {
     font-size: 0.9em; /* Match other control labels */
     cursor: pointer; /* Indicate labels are clickable */
 }
+
+/* Instrument Section Styling */
+.instrument-section legend {
+    margin-bottom: 8px;
+}
+
+.instrument-mode-toggle {
+    margin-bottom: 10px;
+    display: flex;
+    align-items: center;
+}
+
+.instrument-mode-toggle input[type="checkbox"] {
+    margin-right: 6px;
+}
+
+.instrument-mode-toggle label {
+    font-weight: normal;
+    font-size: 0.9em;
+    margin-bottom: 0;
+    cursor: pointer;
+}
+
+.instrument-container {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+    gap: 8px;
+    max-height: 150px;
+    overflow-y: auto;
+    padding: 5px;
+    background-color: #e8e8e8;
+    border-radius: 4px;
+}
+
+.instrument-container.hide {
+    display: none;
+}
+
+/* Styles for individual radio/checkbox items */
+.instrument-container div {
+    display: flex;
+    align-items: center;
+}
+
+.instrument-container input[type="radio"],
+.instrument-container input[type="checkbox"] {
+    margin-right: 6px;
+    cursor: pointer;
+}
+
+.instrument-container label {
+    font-weight: normal;
+    margin-bottom: 0;
+    font-size: 0.9em;
+    cursor: pointer;
+}


### PR DESCRIPTION
Replace the single instrument dropdown with a more flexible UI that allows users to choose between single-instrument mode (via radio buttons) or multi-instrument mode (via checkboxes).

A toggle checkbox controls the active mode. The UI state and internal instrument selection string (`comfyJazz.instrument`) are synchronized when switching modes or making selections. Logic ensures at least one instrument is always selected.

- Introduces radio buttons for single selection (default).
- Introduces checkboxes for multiple selection.
- Adds a toggle to switch between single/multi modes.
- Updates `main.ts` logic for state management, initialization,
  mode switching, and reset functionality.
- Updates `index.html` with the new input structure.
- Adds CSS in `style.css` for the new instrument section layout.

Additionally, this commit:

- Fixes the multi-instrument playback logic in `web/comfyjazz.ts`  to correctly parse the comma-separated string and randomly   select an instrument for each note when in multi-select mode.
- Adds a temporary, dismissible welcome banner to `index.html` and `style.css` with fade-out logic in `main.ts`.
- Removes console logs previously added for debugging key presses.
- Removes the commented-out HTML for the old dropdown menu.
- Removes an unused `instrumentRadios` variable in `main.ts`.